### PR TITLE
Correct duplicated css entry

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -55,7 +55,7 @@
 /* TEN specific                                                                  */
 /*********************************************************************************/
 
-.icon	{
+.feedicon	{
 	margin-right:50px;
 }
 
@@ -1211,7 +1211,7 @@ div.taped-image img{
 			width:100%;
 		}
 		
-		.icon	{
+		.feedicon	{
 			margin-right:20px;
 		}
 		
@@ -1444,7 +1444,7 @@ div.taped-image img{
 
 	@media screen and (max-width: 480px) {
 
-		.icon	{
+		.feedicon	{
 			margin-right:20px;
 		}
 		

--- a/mng_most_commented_feeds.php
+++ b/mng_most_commented_feeds.php
@@ -100,7 +100,7 @@ if($action=='select') {
 
 				//Call function to extract feed thumb from RSS feed - RS 21/03/2017
 				$response .= "<div style='float:right;' class='thumb-container'><img class='feedThumb' src='" . getThumb($rssRow['address']) . "'></div>";
-				$response .= "<h2 style='display:inline; float:left;' class='icon' ><img style='padding-top:10px; display:inline;' src='images/comment.png' width='25px'> " . $count . "</h2>";
+				$response .= "<h2 style='display:inline; float:left;' class='feedicon' ><img style='padding-top:10px; display:inline;' src='images/comment.png' width='25px'> " . $count . "</h2>";
 				$response .= "<h2><a href='#' class='rsslink' rssid='" . $rssRow['rss_id'] . "' >" . $rssRow['title'] . "</a>";
 			
 				//Get rating - added by RS 14/04/2017

--- a/mng_most_subbed_feeds.php
+++ b/mng_most_subbed_feeds.php
@@ -100,7 +100,7 @@ if($action=='select') {
 
 				//Call function to extract feed thumb from RSS feed - RS 21/03/2017
 				$response .= "<div style='float:right;' class='thumb-container'><img class='feedThumb' src='" . getThumb($rssRow['address']) . "'></div>";
-				$response .= "<h2 style='display:inline; float:left;' class='icon' ><img style='padding-top:10px; display:inline;' src='images/placeholder.jpg' width='25px'> " . $count . "</h2>";
+				$response .= "<h2 style='display:inline; float:left;' class='feedicon' ><img style='padding-top:10px; display:inline;' src='images/placeholder.jpg' width='25px'> " . $count . "</h2>";
 				$response .= "<h2><a href='#' class='rsslink' rssid='" . $rssRow['rss_id'] . "' >" . $rssRow['title'] . "</a>";
 			
 				//Get rating - added by RS 14/04/2017

--- a/mng_trending.php
+++ b/mng_trending.php
@@ -105,7 +105,7 @@ if($action=='select') {
 					//generate link and title for RSS Feed
 					//Call function to extract feed thumb from RSS feed - RS 21/03/2017
 					$response .= "<div style='float:right;' class='thumb-container'><img class='feedThumb' src='" . getThumb($rssRow['address']) . "'></div>";
-					$response .= "<h2 style='float:left;' class='icon' ><img src='images/trend.png' height='50px'> " . $count . "</h2>";
+					$response .= "<h2 style='float:left;' class='feedicon' ><img src='images/trend.png' height='50px'> " . $count . "</h2>";
 					$response .= "<h2><a href='#' class='rsslink' rssid='" . $rssRow['rss_id'] . "' >" . $rssRow['title'] . "</a>";
 
 					//Get rating - added by RS 14/04/2017
@@ -251,7 +251,7 @@ if($action=='select') {
 					//generate link and title for RSS Feed
 					//Call function to extract feed thumb from RSS feed - RS 21/03/2017
 					$response .= "<div style='float:right;' class='thumb-container'><img class='feedThumb' src='" . getThumb($rssRow['address']) . "'></div>";
-					$response .= "<h2 style='float:left;' class='icon' ><img src='images/trend.png' height='50px'> " . $count . "</h2>";
+					$response .= "<h2 style='float:left;' class='feedicon' ><img src='images/trend.png' height='50px'> " . $count . "</h2>";
 					$response .= "<h2><a href='#' class='rsslink' rssid='" . $rssRow['rss_id'] . "' >" . $rssRow['title'] . "</a></a>";
 
 					//Get rating - added by RS 14/04/2017
@@ -396,7 +396,7 @@ if($action=='select') {
 					//generate link and title for RSS Feed
 					//Call function to extract feed thumb from RSS feed - RS 21/03/2017
 					$response .= "<div style='float:right;' class='thumb-container'><img class='feedThumb' src='" . getThumb($rssRow['address']) . "'></div>";
-					$response .= "<h2 style='float:left;' class='icon' ><img src='images/trend.png' height='50px'> " . $count . "</h2>";
+					$response .= "<h2 style='float:left;' class='feedicon' ><img src='images/trend.png' height='50px'> " . $count . "</h2>";
 					$response .= "<h2><a href='#' class='rsslink' rssid='" . $rssRow['rss_id'] . "' >" . $rssRow['title'] . "</a></a>";
 
 					//Get rating - added by RS 14/04/2017
@@ -541,7 +541,7 @@ if($action=='select') {
 					//generate link and title for RSS Feed
 					//Call function to extract feed thumb from RSS feed - RS 21/03/2017
 					$response .= "<div style='float:right;' class='thumb-container'><img class='feedThumb' src='" . getThumb($rssRow['address']) . "'></div>";
-					$response .= "<h2 style='float:left;' class='icon' ><img src='images/trend.png' height='50px'> " . $count . "</h2>";
+					$response .= "<h2 style='float:left;' class='feedicon' ><img src='images/trend.png' height='50px'> " . $count . "</h2>";
 					$response .= "<h2><a href='#' class='rsslink' rssid='" . $rssRow['rss_id'] . "' >" . $rssRow['title'] . "</a></a>";
 
 					//Get rating - added by RS 14/04/2017
@@ -680,7 +680,7 @@ if($action=='select') {
 					//generate link and title for RSS Feed
 					//Call function to extract feed thumb from RSS feed - RS 21/03/2017
 					$response .= "<div style='float:right;' class='thumb-container'><img class='feedThumb' src='" . getThumb($rssRow['address']) . "'></div>";
-					$response .= "<h2 style='float:left;' class='icon' ><img src='images/trend.png' height='50px'> " . $count . "</h2>";
+					$response .= "<h2 style='float:left;' class='feedicon' ><img src='images/trend.png' height='50px'> " . $count . "</h2>";
 					$response .= "<h2><a href='#' class='rsslink' rssid='" . $rssRow['rss_id'] . "' >" . $rssRow['title'] . "</a></a>";
 
 					//Get rating - added by RS 14/04/2017


### PR DESCRIPTION
Created a css class of icon for the trending / rating feeds functionality but unfortunately this class was already in use.  This caused the menu button to dissapear on some mobile device browsers.

This small change renames the .icon class introduced to .feedicon and changes the associated code entry points where this class is used.

No code review necessary as only a small change.